### PR TITLE
MOM-726 Fix overlapping events

### DIFF
--- a/Sources/Timeline/TimelineView.swift
+++ b/Sources/Timeline/TimelineView.swift
@@ -438,7 +438,12 @@ public final class TimelineView: UIView {
       let sortedEvents = self.regularLayoutAttributes.sorted { (attr1, attr2) -> Bool in
           let start1 = attr1.descriptor.dateInterval.start
           let start2 = attr2.descriptor.dateInterval.start
-          return start1 < start2
+          if start1 != start2 {
+            return start1 < start2
+          }
+          let end1 = attr1.descriptor.dateInterval.end
+          let end2 = attr2.descriptor.dateInterval.end
+          return end1 < end2
       }
 
       var groupsOfEvents = [[EventLayoutAttributes]]()


### PR DESCRIPTION
This PR fixes the problem with overlapping events. The source of this problem was incorrectly sorting events - only the start date was compared, without looking at how long is specific event. 

Below are some examples of known cases with incorrectly rendered events and fixed version

### **1.  Hidden event nr 17 (covered by event nr 10)** 
![wrong](https://github.com/Codefied/CalendarKit/assets/83907896/b0639a3a-6224-4b66-8a64-94d6e2994bca)

Fixed:
![fixed](https://github.com/Codefied/CalendarKit/assets/83907896/1ce3faa3-47d4-4e89-ada1-050a29303e1a)

----------------------

### **2. Event nr 7 overlaps event nr 12**
![wrong 2](https://github.com/Codefied/CalendarKit/assets/83907896/be2c4597-b270-4231-8610-42fdd780daa4)

Fixed:
![fixed 2](https://github.com/Codefied/CalendarKit/assets/83907896/420881cb-08e8-47c6-ac23-2fa996e8efbe)

----------------------

### **3. Event nr 7 overlaps events nr 12 and 13**
![wrong 3](https://github.com/Codefied/CalendarKit/assets/83907896/b698956f-19e8-4b44-bed6-7329ac4f60cf)

Fixed:
![fixed 3](https://github.com/Codefied/CalendarKit/assets/83907896/e67f8ba2-2a84-43ff-90a4-83d33b93abcc)

